### PR TITLE
Add Playwright integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,11 @@ jobs:
       - name: Test
         run: npm test
 
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Integration test
+        run: npm run test:integration
+
       - name: Build
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+playwright-report
+test-results
 *.local
 
 #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
   and build tooling in shells where `NODE_ENV=production`.
 - `npm run dev` - start the Vite development server.
 - `NODE_ENV=test npm run test` - run the Vitest test suite once.
+- `npm run test:integration` - run the Playwright browser integration tests.
 - `npm run lint` - run ESLint across the repository.
 - `npm run build` - run TypeScript project builds and create the Vite production build.
 - `npm run preview` - preview the built Vite app locally after a build.
@@ -27,6 +28,7 @@
 - `src/components/Square.tsx` - individual board square button.
 - `src/components/*.test.tsx` - colocated React Testing Library and Vitest tests.
 - `src/test/setup.ts` - shared Vitest setup for cleanup and jest-dom matchers.
+- `tests/integration/*.spec.ts` - Playwright browser integration tests.
 - `public/` - static assets served by Vite.
 
 ## Working rules
@@ -42,6 +44,7 @@
 
 ## Testing
 - Run `NODE_ENV=test npm run test` for component and game behavior changes.
+- Run `npm run test:integration` for end-to-end browser coverage.
 - Run `npm run lint` for TypeScript,
   React,
   and hook rule checks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@eslint-react/eslint-plugin": "^2.3.4",
         "@eslint/js": "^9.36.0",
+        "@playwright/test": "^1.61.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1455,6 +1456,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4016,6 +4033,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:integration": "playwright test"
   },
   "dependencies": {
     "react": "^19.1.1",
@@ -17,6 +18,7 @@
   "devDependencies": {
     "@eslint-react/eslint-plugin": "^2.3.4",
     "@eslint/js": "^9.36.0",
+    "@playwright/test": "^1.61.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025.
+ * valo.media GmbH
+ * All rights reserved.
+ */
+
+//
+//  playwright.config.ts
+//  connect-four
+//
+//  Created by:
+//      * OpenClaw
+//
+
+import {defineConfig, devices} from '@playwright/test';
+
+export default defineConfig({
+    testDir: './tests/integration',
+    fullyParallel: true,
+    reporter: 'list',
+    use: {
+        baseURL: 'http://127.0.0.1:5173',
+        trace: 'on-first-retry',
+    },
+    webServer: {
+        command: 'npm run dev -- --host 127.0.0.1 --strictPort',
+        url: 'http://127.0.0.1:5173',
+        reuseExistingServer: true,
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: {...devices['Desktop Chrome']},
+        },
+    ],
+});

--- a/tests/integration/connect-four.spec.ts
+++ b/tests/integration/connect-four.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025.
+ * valo.media GmbH
+ * All rights reserved.
+ */
+
+//
+//  connect-four.spec.ts
+//  connect-four
+//
+//  Created by:
+//      * OpenClaw
+//
+
+import {expect, test, type Locator, type Page} from '@playwright/test';
+
+function getSquares(page: Page): Locator {
+    return page.getByRole('button', {name: 'O'});
+}
+
+async function playColumn(page: Page, column: number): Promise<void> {
+    await getSquares(page).nth(column - 1).click();
+}
+
+test.describe('Connect Four', () => {
+    test('renders an empty board in the browser', async ({page}) => {
+        await page.goto('/');
+
+        await expect(page.getByRole('heading', {name: 'Connect Four'})).toBeVisible();
+        await expect(page.getByText("It's red's turn")).toBeVisible();
+        await expect(getSquares(page)).toHaveCount(42);
+        await expect(getSquares(page).first()).toHaveClass(/square-empty/);
+    });
+
+    test('plays a winning game and resets from the browser', async ({page}) => {
+        await page.goto('/');
+
+        await playColumn(page, 1); // red
+        await playColumn(page, 7); // blue
+        await playColumn(page, 2); // red
+        await playColumn(page, 7); // blue
+        await playColumn(page, 3); // red
+        await playColumn(page, 7); // blue
+        await playColumn(page, 4); // red wins horizontally
+
+        await expect(page.getByText('red won the game!')).toBeVisible();
+        await expect(getSquares(page).nth(35)).toHaveClass(/square-red/);
+        await expect(getSquares(page).nth(38)).toHaveClass(/square-red/);
+
+        await playColumn(page, 5);
+
+        await expect(getSquares(page).nth(39)).toHaveClass(/square-empty/);
+
+        await page.getByRole('button', {name: 'Reset'}).click();
+
+        await expect(page.getByText('red won the game!')).toHaveCount(0);
+        await expect(page.getByText("It's red's turn")).toBeVisible();
+        await expect(getSquares(page).first()).toHaveClass(/square-empty/);
+    });
+});

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "playwright.config.ts", "tests"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,13 +12,14 @@
 //      * Jean-Pierre Höhmann
 //
 
-import { defineConfig } from 'vitest/config'
+import {configDefaults, defineConfig} from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',
+    exclude: [...configDefaults.exclude, 'tests/integration/**'],
     setupFiles: './src/test/setup.ts',
   },
 })


### PR DESCRIPTION
closes valomedia/connect-four#50

Adds Playwright browser integration testing for the Connect Four app. The branch introduces @playwright/test, a Chromium-only Playwright config, and end-to-end tests that verify the app renders, completes a horizontal red win, blocks further moves after game over, and resets the board. It adds npm run test:integration, excludes integration specs from Vitest discovery, ignores Playwright artifacts, includes the new config/tests in TypeScript node config, documents the integration test command and layout in AGENTS.md, and updates GitHub Actions to install Chromium and run the integration suite alongside lint, unit tests, and build. Verification passed: npm run test:integration. Committed as 56dc441 with message: test: add Playwright integration tests.