### PR TITLE
chore: set up Renovate dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>valomedia/renovate-config"]
+}


### PR DESCRIPTION
closes valomedia/connect-four#40

Added a root-level renovate.json that extends github>valomedia/renovate-config, enabling Renovate for the repository through the shared valo.media preset. Confirmed the repo has Renovate inputs for npm and GitHub Actions via package.json, package-lock.json, and .github/workflows/ci.yml; before this config lands there were no existing Dependency Dashboard or Renovate-authored PRs. The shared preset enables the Dependency Dashboard, groups GitHub Actions and npm development dependency updates, and only automerges lockfile maintenance and stable patch PRs after required status checks pass. Verification passed: validated renovate.json schema/extends and expected dependency files with a Node script, then ran npm run lint successfully. Committed changes as b946a15 (chore: configure renovate).