### PR TITLE
Apply GitHub Actions workflow best practices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,20 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@main
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -26,14 +30,65 @@ jobs:
       - name: Lint
         run: npm run lint
 
+  unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --include=dev
+
       - name: Test
-        run: npm test
+        run: NODE_ENV=test npm run test
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --include=dev
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
       - name: Integration test
         run: npm run test:integration
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --include=dev
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
closes valomedia/connect-four#54

Updated `.github/workflows/ci.yml` to apply CI workflow best practices: added least-privilege top-level `contents: read` permissions, switched workflow actions to current stable major tags (`actions/checkout@v7` and `actions/setup-node@v6`), added explicit job timeouts, and split CI into separate `lint`, `unit-tests`, `integration-tests`, and `build` jobs for clearer GitHub Checks diagnostics. The unit test job now runs `NODE_ENV=test npm run test` to match repository guidance. Verification passed with workflow YAML parsing, `npm run lint`, `NODE_ENV=test npm run test`, `npm run build`, and `npm run test:integration`. Committed changes with `ci: apply workflow best practices`.