### PR TITLE
Add scheduled SFTP CD via shared workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,23 @@
+name: CD
+
+on:
+  schedule:
+    - cron: '37 3 * * 5'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  deploy:
+    uses: valomedia/github-workflows/.github/workflows/scheduled-sftp-release.yml@v1.0.2
+    with:
+      ci-workflow: ci.yml
+      build-command: npm run build
+      dist-path: dist
+      sftp-host: ${{ vars.SFTP_HOST }}
+      sftp-port: ${{ vars.SFTP_PORT || '22' }}
+      sftp-username: ${{ vars.SFTP_USERNAME }}
+      sftp-remote-path: ${{ vars.SFTP_REMOTE_PATH }}
+    secrets: inherit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "connect-four",
-  "version": "0.1.3",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "connect-four",
-      "version": "0.1.3",
+      "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connect-four",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
         trace: 'on-first-retry',
     },
     webServer: {
-        command: 'npm run dev -- --host 127.0.0.1 --strictPort',
+        command: 'NODE_ENV=test npm run dev -- --host 127.0.0.1 --strictPort',
         url: 'http://127.0.0.1:5173',
         reuseExistingServer: true,
     },


### PR DESCRIPTION
closes valomedia/connect-four#63

The branch adds a thin Connect Four CD workflow scheduled for Fridays at 37 3 * * 5 UTC with workflow_dispatch support. The wrapper calls valomedia/github-workflows/.github/workflows/scheduled-sftp-release.yml@v1.0.2, passes the CI workflow/build/dist settings and repo SFTP variables, and inherits secrets. It also sets package.json and the package-lock root version to 0.0.0 and updates the Playwright web server command to run Vite with NODE_ENV=test for stable integration-test verification. The shared private valomedia/github-workflows repository has main and tag v1.0.2 at b208bbd, containing the reusable scheduled SFTP release workflow plus SFTP deploy and calendar release composite actions; the shared flow checks successful CI for the exact deployed main SHA, skips when there are no commits since the previous release, builds dist, syncs via SFTP with stale-file deletion while preserving root .ht* files, and creates generated-notes GitHub Releases targeting the checked/deployed SHA. Verification passed: npm ci --include=dev, npm run lint, NODE_ENV=test npm run test, npm run build, npm run test:integration, git diff --check, YAML parsing for local CI/CD and shared workflow/action files, and gh API checks for v1.0.2 at b208bbd plus shared target-sha/delete/exclude wiring. Local changes were committed as 57f5195 ci: add scheduled SFTP release workflow.