### PR TITLE
Add Docker-backed devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,10 +2,8 @@
 
 FROM mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm
 
-ARG PLAYWRIGHT_VERSION=1.61.1
-
 COPY prepare-volumes-and-drop-sudo.sh /usr/local/bin/connect-four-devcontainer-prepare-volumes
 
-RUN npx --yes playwright@${PLAYWRIGHT_VERSION} install-deps chromium \
+RUN npx --yes playwright install-deps chromium \
     && npm cache clean --force \
     && chmod 0755 /usr/local/bin/connect-four-devcontainer-prepare-volumes

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1
+
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm
+
+ARG PLAYWRIGHT_VERSION=1.61.1
+
+COPY prepare-volumes-and-drop-sudo.sh /usr/local/bin/connect-four-devcontainer-prepare-volumes
+
+RUN npx --yes playwright@${PLAYWRIGHT_VERSION} install-deps chromium \
+    && npm cache clean --force \
+    && chmod 0755 /usr/local/bin/connect-four-devcontainer-prepare-volumes

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,10 +2,7 @@
   "name": "Connect Four",
   "build": {
     "dockerfile": "Dockerfile",
-    "context": ".",
-    "args": {
-      "PLAYWRIGHT_VERSION": "1.61.1"
-    }
+    "context": "."
   },
   "remoteUser": "node",
   "containerEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "Connect Four",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".",
+    "args": {
+      "PLAYWRIGHT_VERSION": "1.61.1"
+    }
+  },
+  "remoteUser": "node",
+  "containerEnv": {
+    "NODE_ENV": "development"
+  },
+  "mounts": [
+    "source=${localWorkspaceFolderBasename}-node-modules,target=${containerWorkspaceFolder}/node_modules,type=volume",
+    "source=${localWorkspaceFolderBasename}-npm-cache,target=/home/node/.npm,type=volume",
+    "source=${localWorkspaceFolderBasename}-playwright-cache,target=/home/node/.cache/ms-playwright,type=volume"
+  ],
+  "postCreateCommand": "sudo /usr/local/bin/connect-four-devcontainer-prepare-volumes \"${containerWorkspaceFolder}/node_modules\" /home/node/.npm /home/node/.cache/ms-playwright && npm ci --include=dev && npx playwright install chromium",
+  "forwardPorts": [5173],
+  "portsAttributes": {
+    "5173": {
+      "label": "Vite dev server",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "vitest.explorer",
+        "ms-playwright.playwright"
+      ]
+    }
+  }
+}

--- a/.devcontainer/prepare-volumes-and-drop-sudo.sh
+++ b/.devcontainer/prepare-volumes-and-drop-sudo.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This setup helper must run as root." >&2
+  exit 1
+fi
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: $0 <writable-path> [<writable-path> ...]" >&2
+  exit 1
+fi
+
+for writable_path in "$@"; do
+  mkdir -p "$writable_path"
+  chown -R node:node "$writable_path"
+done
+
+remove_passwordless_sudo() {
+  local sudoers_file="$1"
+
+  if grep -Eq '(^|[[:space:]])(node|%sudo)[[:space:]].*NOPASSWD' "$sudoers_file"; then
+    sed -i -E '/(^|[[:space:]])(node|%sudo)[[:space:]].*NOPASSWD/d' "$sudoers_file"
+
+    if [ "$sudoers_file" != /etc/sudoers ] && [ ! -s "$sudoers_file" ]; then
+      rm -f "$sudoers_file"
+    fi
+  fi
+}
+
+if [ -f /etc/sudoers ]; then
+  remove_passwordless_sudo /etc/sudoers
+fi
+
+if [ -d /etc/sudoers.d ]; then
+  while IFS= read -r -d '' sudoers_file; do
+    remove_passwordless_sudo "$sudoers_file"
+  done < <(find /etc/sudoers.d -type f -print0)
+fi
+
+if getent group sudo >/dev/null && id -nG node | tr ' ' '\n' | grep -qx sudo; then
+  gpasswd --delete node sudo >/dev/null 2>&1 || true
+fi
+
+passwd --lock node >/dev/null 2>&1 || true
+
+if command -v visudo >/dev/null 2>&1; then
+  visudo -cf /etc/sudoers >/dev/null
+fi

--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
 # Connect Four
 
-Toy implementation of the connect four kids game, used as a sandbox for training and coding challenges.
+Toy implementation of the connect four kids game,
+used as a sandbox for training and coding challenges.
+
+## Development container
+
+This repository includes a Docker-backed devcontainer
+so the full npm-based development workflow can run away from the host system.
+Open the project with VS Code Dev Containers
+or any compatible devcontainer client.
+The container uses Node.js 22,
+installs dependencies with `npm ci --include=dev`,
+and installs Chromium for Playwright integration tests during post-create setup.
+
+The devcontainer runs as the non-root `node` user,
+does not mount the host Docker socket,
+and keeps `node_modules`,
+the npm cache,
+and the Playwright browser cache in Docker named volumes.
+Its one-time setup uses sudo only to make those named volumes writable,
+then removes passwordless sudo before running `npm ci`.
+That keeps package-manager side effects inside Docker while leaving the source tree editable.
+
+Common commands inside the container:
+
+- `npm run dev` - start the Vite development server on port 5173.
+- `npm run lint` - run ESLint.
+- `NODE_ENV=test npm run test` - run the Vitest suite once.
+- `npm run test:integration` - run the Playwright integration tests.
+- `npm run build` - typecheck and build the production app.


### PR DESCRIPTION
closes valomedia/connect-four#67

Added a Docker-backed devcontainer for the Connect Four npm workflow. The branch adds .devcontainer/devcontainer.json with a Node.js 22 container running as the non-root node user, Docker named volumes for node_modules, npm cache, and Playwright cache, Vite port forwarding, and post-create setup that installs npm dependencies plus Chromium. The Dockerfile installs Playwright Chromium system dependencies and installs a root-owned setup helper. The helper prepares named volume mount points, removes passwordless sudo rules, removes node from the sudo group when present, and locks the node password before npm lifecycle scripts run. README.md now documents the devcontainer, common workflow commands, named volumes, and sudo hardening. Committed as 70918fe with message: feat: add Docker-backed devcontainer. Verification passed: parsed .devcontainer/devcontainer.json as JSON, ran bash -n .devcontainer/prepare-volumes-and-drop-sudo.sh, git diff --check, npm ci --include=dev, npm run lint, NODE_ENV=test npm run test, npm run build, and npm run test:integration. Docker and the devcontainer CLI are not installed in this worker environment, so the devcontainer image could not be built locally.