### PR TITLE
Remove redundant top-of-file bylines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,14 +4,6 @@
 # All rights reserved.
 #
 
-##
-##  .gitignore
-##  connect-four
-##
-##  Created by:
-##      * Jean-Pierre Höhmann
-##
-
 #
 # Logs
 #

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 # All rights reserved.
 #
 
+##
+##  .gitignore
+##  connect-four
+##
+
 #
 # Logs
 #

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,11 @@
  * All rights reserved.
  */
 
+//
+//  eslint.config.js
+//  connect-four
+//
+
 import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,14 +4,6 @@
  * All rights reserved.
  */
 
-//
-//  eslint.config.js
-//  connect-four
-//
-//  Created by:
-//      * Jean-Pierre Höhmann
-//
-
 import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'

--- a/index.html
+++ b/index.html
@@ -4,6 +4,11 @@
   ~ All rights reserved.
   -->
 
+<!--
+    index.html
+    connect-four
+-->
+
 <!doctype html>
 <html lang='en'>
 

--- a/index.html
+++ b/index.html
@@ -4,14 +4,6 @@
   ~ All rights reserved.
   -->
 
-<!--
-    index.html
-    connect-four
-
-    Created by:
-        * Jean-Pierre Höhmann
--->
-
 <!doctype html>
 <html lang='en'>
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,11 @@
  * All rights reserved.
  */
 
+//
+//  playwright.config.ts
+//  connect-four
+//
+
 import {defineConfig, devices} from '@playwright/test';
 
 export default defineConfig({

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,14 +4,6 @@
  * All rights reserved.
  */
 
-//
-//  playwright.config.ts
-//  connect-four
-//
-//  Created by:
-//      * OpenClaw
-//
-
 import {defineConfig, devices} from '@playwright/test';
 
 export default defineConfig({

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -6,14 +6,6 @@
   ~ All rights reserved.
   -->
 
-<!--
-    icon.svg
-    petrus
-
-    Created by:
-        * Jonathan Engelland
--->
-
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 300 300">
     <defs>
         <style>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -6,6 +6,11 @@
   ~ All rights reserved.
   -->
 
+<!--
+    icon.svg
+    petrus
+-->
+
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 300 300">
     <defs>
         <style>

--- a/src/App.css
+++ b/src/App.css
@@ -4,14 +4,6 @@
  * All rights reserved.
  */
 
-/*
-    App.css
-    connect-four
-
-    Created by:
-        * Jean-Pierre Höhmann
- */
-
 #root {
     max-width: 1280px;
     margin: 0 auto;

--- a/src/App.css
+++ b/src/App.css
@@ -4,6 +4,11 @@
  * All rights reserved.
  */
 
+/*
+    App.css
+    connect-four
+ */
+
 #root {
     max-width: 1280px;
     margin: 0 auto;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,14 +4,6 @@
  * All rights reserved.
  */
 
-//
-//  App.tsx
-//  connect-four
-//
-//  Created by:
-//      * Jean-Pierre Höhmann
-//
-
 import './App.css';
 import Board from './components/Board.tsx';
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,11 @@
  * All rights reserved.
  */
 
+//
+//  App.tsx
+//  connect-four
+//
+
 import './App.css';
 import Board from './components/Board.tsx';
 

--- a/src/components/Board.css
+++ b/src/components/Board.css
@@ -4,15 +4,6 @@
  * All rights reserved.
  */
 
-/*
-    Board.css
-    connect-four
-
-    Created by:
-        * Daniel Schilling
-        * Jean-Pierre Höhmann
-*/
-
 .turn-text {
     font-size: 2.5em;
 }

--- a/src/components/Board.css
+++ b/src/components/Board.css
@@ -4,6 +4,11 @@
  * All rights reserved.
  */
 
+/*
+    Board.css
+    connect-four
+*/
+
 .turn-text {
     font-size: 2.5em;
 }

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -4,14 +4,6 @@
  * All rights reserved.
  */
 
-//
-//  Board.tsx
-//  connect-four
-//
-//  Created by:
-//      * Daniel Schilling
-//
-
 import {useState} from 'react';
 import Square from './Square.tsx';
 import './Board.css';

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -4,6 +4,11 @@
  * All rights reserved.
  */
 
+//
+//  Board.tsx
+//  connect-four
+//
+
 import {useState} from 'react';
 import Square from './Square.tsx';
 import './Board.css';

--- a/src/components/Square.css
+++ b/src/components/Square.css
@@ -4,6 +4,11 @@
  * All rights reserved.
  */
 
+/*
+    Square.css
+    connect-four
+ */
+
 .square {
     border: 1px solid #999;
     border-radius: 0;

--- a/src/components/Square.css
+++ b/src/components/Square.css
@@ -4,14 +4,6 @@
  * All rights reserved.
  */
 
-/*
-    Square.css
-    connect-four
-
-    Created by:
-        * Daniel Schilling
- */
-
 .square {
     border: 1px solid #999;
     border-radius: 0;

--- a/src/components/Square.tsx
+++ b/src/components/Square.tsx
@@ -4,6 +4,11 @@
  * All rights reserved.
  */
 
+//
+//  Square.tsx
+//  connect-four
+//
+
 import './Square.css';
 
 /**

--- a/src/components/Square.tsx
+++ b/src/components/Square.tsx
@@ -4,14 +4,6 @@
  * All rights reserved.
  */
 
-//
-//  Square.tsx
-//  connect-four
-//
-//  Created by:
-//      * Daniel Schilling
-//
-
 import './Square.css';
 
 /**

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,11 @@
  * All rights reserved.
  */
 
+/*
+    index.css
+    connect-four
+ */
+
 :root {
     font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
     line-height: 1.5;

--- a/src/index.css
+++ b/src/index.css
@@ -4,14 +4,6 @@
  * All rights reserved.
  */
 
-/*
-    index.css
-    connect-four
-
-    Created by:
-        * Jean-Pierre Höhmann
- */
-
 :root {
     font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
     line-height: 1.5;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,14 +4,6 @@
  * All rights reserved.
  */
 
-//
-//  main.tsx
-//  connect-four
-//
-//  Created by:
-//      * Jean-Pierre Höhmann
-//
-
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,11 @@
  * All rights reserved.
  */
 
+//
+//  main.tsx
+//  connect-four
+//
+
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';

--- a/tests/integration/connect-four.spec.ts
+++ b/tests/integration/connect-four.spec.ts
@@ -4,14 +4,6 @@
  * All rights reserved.
  */
 
-//
-//  connect-four.spec.ts
-//  connect-four
-//
-//  Created by:
-//      * OpenClaw
-//
-
 import {expect, test, type Locator, type Page} from '@playwright/test';
 
 function getSquares(page: Page): Locator {

--- a/tests/integration/connect-four.spec.ts
+++ b/tests/integration/connect-four.spec.ts
@@ -4,6 +4,11 @@
  * All rights reserved.
  */
 
+//
+//  connect-four.spec.ts
+//  connect-four
+//
+
 import {expect, test, type Locator, type Page} from '@playwright/test';
 
 function getSquares(page: Page): Locator {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,14 +4,6 @@
  * All rights reserved.
  */
 
-//
-//  vite.config.ts
-//  connect-four
-//
-//  Created by:
-//      * Jean-Pierre Höhmann
-//
-
 import {configDefaults, defineConfig} from 'vitest/config'
 import react from '@vitejs/plugin-react'
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,11 @@
  * All rights reserved.
  */
 
+//
+//  vite.config.ts
+//  connect-four
+//
+
 import {configDefaults, defineConfig} from 'vitest/config'
 import react from '@vitejs/plugin-react'
 


### PR DESCRIPTION
closes valomedia/connect-four#69

Removed redundant top-of-file author/byline/creation-date comment blocks from all 15 detected files while preserving existing copyright/license headers and leaving runtime/documentation comments untouched. Committed as cd7a8f1 (chore: remove redundant file bylines). Verification passed: byline search found no remaining matches; git diff --check passed; npm run lint passed; NODE_ENV=test npm run test passed; npm run test:integration passed; npm run build passed.